### PR TITLE
Initialize ViewRenderable with transparent texture and set it in material right away

### DIFF
--- a/core/src/main/java/com/google/ar/sceneform/rendering/RenderViewToExternalTexture.java
+++ b/core/src/main/java/com/google/ar/sceneform/rendering/RenderViewToExternalTexture.java
@@ -53,8 +53,24 @@ class RenderViewToExternalTexture extends LinearLayout {
 
     externalTexture = new ExternalTexture();
 
+    initializeWithTransparentTexture();
+
     this.view = view;
     addView(view);
+  }
+
+  private void initializeWithTransparentTexture() {
+    externalTexture.getSurfaceTexture().setDefaultBufferSize(1, 1);
+
+    // Sanity that the surface is valid.
+    Surface targetSurface = externalTexture.getSurface();
+    if (!targetSurface.isValid()) {
+      return;
+    }
+
+    Canvas surfaceCanvas = targetSurface.lockCanvas(null);
+    surfaceCanvas.drawColor(Color.TRANSPARENT, PorterDuff.Mode.CLEAR);
+    targetSurface.unlockCanvasAndPost(surfaceCanvas);
   }
 
   /**

--- a/core/src/main/java/com/google/ar/sceneform/rendering/ViewRenderable.java
+++ b/core/src/main/java/com/google/ar/sceneform/rendering/ViewRenderable.java
@@ -233,22 +233,15 @@ public class ViewRenderable extends Renderable {
     ViewRenderableInternalData data = Preconditions.checkNotNull(viewRenderableData);
     RenderViewToExternalTexture renderViewToExternalTexture = data.getRenderView();
 
+    getMaterial().setExternalTexture("viewTexture", renderViewToExternalTexture.getExternalTexture());
+
     if (!renderViewToExternalTexture.isAttachedToWindow()
         || !renderViewToExternalTexture.isLaidOut()) {
       // Wait for the view to finish attachment.
       return;
     }
 
-    // Wait until one frame after the surface texture has been drawn to for the first time.
-    // Fixes an issue where the ViewRenderable would render black for a frame before displaying.
-    boolean hasDrawnToSurfaceTexture = renderViewToExternalTexture.hasDrawnToSurfaceTexture();
-    if (!hasDrawnToSurfaceTexture) {
-      return;
-    }
-
     if (!isInitialized) {
-      getMaterial()
-          .setExternalTexture("viewTexture", renderViewToExternalTexture.getExternalTexture());
       updateSuggestedCollisionShape();
 
       isInitialized = true;


### PR DESCRIPTION
The texture is now initialized with one transparent pixel so it is safe to use it for rendering.