### PR TITLE
Add support for using sceneform sdk as a dynamic module

### DIFF
--- a/core/src/main/java/com/google/ar/sceneform/rendering/CameraStream.java
+++ b/core/src/main/java/com/google/ar/sceneform/rendering/CameraStream.java
@@ -178,7 +178,7 @@ public class CameraStream {
                 Material.builder()
                         .setSource(
                                 renderer.getContext(),
-                                RenderingResources.GetSceneformResource(
+                                RenderingResources.GetSceneformSourceResourceUri(
                                         renderer.getContext(),
                                         RenderingResources.Resource.CAMERA_MATERIAL))
                         .build();
@@ -212,7 +212,7 @@ public class CameraStream {
                 Material.builder()
                         .setSource(
                                 renderer.getContext(),
-                                RenderingResources.GetSceneformResource(
+                                RenderingResources.GetSceneformSourceResourceUri(
                                         renderer.getContext(),
                                         RenderingResources.Resource.OCCLUSION_CAMERA_MATERIAL))
                         .build();

--- a/core/src/main/java/com/google/ar/sceneform/rendering/MaterialFactory.java
+++ b/core/src/main/java/com/google/ar/sceneform/rendering/MaterialFactory.java
@@ -83,7 +83,7 @@ public final class MaterialFactory {
         Material.builder()
             .setSource(
                 context,
-                RenderingResources.GetSceneformResource(
+                RenderingResources.GetSceneformSourceResourceUri(
                     context, RenderingResources.Resource.OPAQUE_COLORED_MATERIAL))
             .build();
 
@@ -115,7 +115,7 @@ public final class MaterialFactory {
         Material.builder()
             .setSource(
                 context,
-                RenderingResources.GetSceneformResource(
+                RenderingResources.GetSceneformSourceResourceUri(
                     context, RenderingResources.Resource.TRANSPARENT_COLORED_MATERIAL))
             .build();
 
@@ -148,7 +148,7 @@ public final class MaterialFactory {
         Material.builder()
             .setSource(
                 context,
-                RenderingResources.GetSceneformResource(
+                RenderingResources.GetSceneformSourceResourceUri(
                     context, RenderingResources.Resource.OPAQUE_TEXTURED_MATERIAL))
             .build();
 
@@ -181,7 +181,7 @@ public final class MaterialFactory {
         Material.builder()
             .setSource(
                 context,
-                RenderingResources.GetSceneformResource(
+                RenderingResources.GetSceneformSourceResourceUri(
                     context, RenderingResources.Resource.TRANSPARENT_TEXTURED_MATERIAL))
             .build();
 

--- a/core/src/main/java/com/google/ar/sceneform/rendering/PlaneRenderer.java
+++ b/core/src/main/java/com/google/ar/sceneform/rendering/PlaneRenderer.java
@@ -309,7 +309,7 @@ public class PlaneRenderer {
         Material.builder()
                 .setSource(
                         renderer.getContext(),
-                        RenderingResources.GetSceneformResource(
+                        RenderingResources.GetSceneformSourceResourceUri(
                                 renderer.getContext(), RenderingResources.Resource.PLANE_SHADOW_MATERIAL))
                 .build()
                 .thenAccept(
@@ -338,7 +338,7 @@ public class PlaneRenderer {
                 Texture.builder()
                         .setSource(
                                 renderer.getContext(),
-                                RenderingResources.GetSceneformResource(
+                                RenderingResources.GetSceneformSourceResourceUri(
                                         renderer.getContext(), RenderingResources.Resource.PLANE))
                         .setSampler(sampler)
                         .build();
@@ -347,7 +347,7 @@ public class PlaneRenderer {
                 Material.builder()
                         .setSource(
                                 renderer.getContext(),
-                                RenderingResources.GetSceneformResource(
+                                RenderingResources.GetSceneformSourceResourceUri(
                                         renderer.getContext(), RenderingResources.Resource.PLANE_MATERIAL))
                         .build()
                         .thenCombine(

--- a/core/src/main/java/com/google/ar/sceneform/rendering/RenderingResources.java
+++ b/core/src/main/java/com/google/ar/sceneform/rendering/RenderingResources.java
@@ -1,7 +1,9 @@
 package com.google.ar.sceneform.rendering;
 
 import android.content.Context;
+import android.net.Uri;
 
+import com.google.ar.sceneform.R;
 import com.google.ar.sceneform.utilities.LoadHelper;
 
 final class RenderingResources {
@@ -50,6 +52,31 @@ final class RenderingResources {
     return 0;
   }
 
+  static Uri GetSceneformSourceResourceUri(Context context, Resource resource) {
+    switch (resource) {
+      case CAMERA_MATERIAL:
+        return LoadHelper.resourceToUri(context, R.raw.ar_environment_material_flat);
+      case OCCLUSION_CAMERA_MATERIAL:
+        return LoadHelper.resourceToUri(context, R.raw.ar_environment_material_depth);
+      case OPAQUE_COLORED_MATERIAL:
+        return LoadHelper.resourceToUri(context, R.raw.sceneform_opaque_colored_material);
+      case TRANSPARENT_COLORED_MATERIAL:
+        return LoadHelper.resourceToUri(context, R.raw.sceneform_transparent_colored_material);
+      case OPAQUE_TEXTURED_MATERIAL:
+        return LoadHelper.resourceToUri(context, R.raw.sceneform_opaque_textured_material);
+      case TRANSPARENT_TEXTURED_MATERIAL:
+        return LoadHelper.resourceToUri(context, R.raw.sceneform_transparent_textured_material);
+      case PLANE_SHADOW_MATERIAL:
+        return LoadHelper.resourceToUri(context, R.raw.sceneform_plane_shadow_material);
+      case PLANE_MATERIAL:
+        return LoadHelper.resourceToUri(context, R.raw.sceneform_plane_material);
+      case PLANE:
+        return LoadHelper.resourceToUri(context, R.drawable.sceneform_plane);
+      case VIEW_RENDERABLE_MATERIAL:
+        return LoadHelper.resourceToUri(context, R.raw.sceneform_view_material);
+    }
+    return null;
+  }
   
   private static int GetMaterialFactoryBlazeResource(Resource resource) {return 0;}
 

--- a/core/src/main/java/com/google/ar/sceneform/rendering/ViewRenderable.java
+++ b/core/src/main/java/com/google/ar/sceneform/rendering/ViewRenderable.java
@@ -442,7 +442,7 @@ public class ViewRenderable extends Renderable {
         CompletableFuture<Void> setSourceFuture = Material.builder()
                 .setSource(
                         context,
-                        RenderingResources.GetSceneformResource(
+                        RenderingResources.GetSceneformSourceResourceUri(
                                 context, RenderingResources.Resource.VIEW_RENDERABLE_MATERIAL))
                 .build()
                 .thenAccept(

--- a/core/src/main/java/com/google/ar/sceneform/utilities/LoadHelper.java
+++ b/core/src/main/java/com/google/ar/sceneform/utilities/LoadHelper.java
@@ -142,9 +142,12 @@ public class LoadHelper {
     Resources resources = context.getResources();
     return new Uri.Builder()
         .scheme(ContentResolver.SCHEME_ANDROID_RESOURCE)
-        .authority(resources.getResourcePackageName(resID))
+        .authority(context.getPackageName()) // Look up the resources in the application with its splits loaded
         .appendPath(resources.getResourceTypeName(resID))
-        .appendPath(resources.getResourceEntryName(resID))
+        .appendPath(String.format("%s:%s",
+                resources.getResourcePackageName(resID), // Look up the dynamic resource in the split namespace.
+                resources.getResourceEntryName(resID)
+        ))
         .build();
   }
 


### PR DESCRIPTION
Currently, Sceneform sdk does not support and cannot be used as a dynamic module to make use of the https://developer.android.com/guide/playcore/feature-delivery to reduce app size.

This PR resolves https://github.com/SceneView/sceneform-android/issues/441 bug.

I have made changes as described at https://developer.android.com/guide/playcore/feature-delivery#resource-uri for supporting dynamic module.

@ThomasGorisse , @RGregat, @grassydragon, @nvictornvictor, Please have a look at it. This change allows to use the sdk as an Android dynamic modules without impacting the current behavior.

**Testing:**
- Verified that all the sample applications work correctly with these new changes.
- Verified that https://github.com/SceneView/sceneform-android/issues/441 issue is resolved after applying the PR changes